### PR TITLE
Removed EEPROM references, swapped clock/data pins in addLeds call

### DIFF
--- a/BiblioPixelSerialReceiver.ino
+++ b/BiblioPixelSerialReceiver.ino
@@ -7,13 +7,13 @@ https://github.com/ManiacalLabs/BiblioPixelSmartMatrix
 **********************************/
 
 #include "FastLED.h"
-#include <EEPROM.h>
+//#include <EEPROM.h> // not available in M0
 
 /****************************
 All Firmware options go here!
 ****************************/
 // How many leds in your strip?
-#define NUM_LEDS 8 * 8
+#define NUM_LEDS 32 * 56
 
 #define DATA_PIN MOSI
 #define CLOCK_PIN SCK
@@ -67,7 +67,7 @@ inline void setupFastLED()
     //Just change the config options above
 
     //Data and Clock LEDs
-    FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS);
+  FastLED.addLeds<LED_TYPE, CLOCK_PIN, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS); // swap clock/data pins
 
     //Data only LEDs
     //FastLED.addLeds<LED_TYPE, DATA_PIN, COLOR_ORDER>(leds, NUM_LEDS);
@@ -76,13 +76,22 @@ inline void setupFastLED()
     FastLED.show();
 }
 
+void fill(const struct CRGB & color){
+  for(int ii=0; ii<NUM_LEDS; ii++){
+    leds[ii] = color;
+    if(ii % 8 == 7){
+      FastLED.show();
+    }
+  }
+}
 void setup()
 {
+    setupFastLED();
+    //FastLED.setBrightness(4); fill(CRGB::Blue);fill(CRGB::Black);
+
     // Full USB 1.1 speed, assuming your chip has native USB
     Serial.begin(12000000);
     Serial.setTimeout(1000);
-
-    setupFastLED();
 }
 
 #define EMPTYMAX 100
@@ -137,7 +146,7 @@ inline void getData()
         }
         else if(cmd == CMDTYPE::GETID)
         {
-            Serial.write(EEPROM.read(16));
+	  //Serial.write(EEPROM.read(16));
         }
         else if(cmd == CMDTYPE::SETID)
         {
@@ -148,7 +157,7 @@ inline void getData()
             else
             {
                 uint8_t id = Serial.read();
-                EEPROM.write(16, id);
+                //EEPROM.write(16, id);
                 Serial.write(RETURN_CODES::SUCCESS);
             }
         }

--- a/biblio_test.py
+++ b/biblio_test.py
@@ -1,0 +1,21 @@
+from numpy import *
+import bibliopixel.drivers.serial_driver as driver
+import bibliopixel.animation as animation
+import bibliopixel.led as led
+
+s = driver.DriverSerial(driver.LEDTYPE.APA102, 64*9, dev="/dev/ttyACM0")
+led = led.LEDStrip(s)
+led.setMasterBrightness(4)
+print 'here'
+# here
+
+a = animation.StripChannelTest(led)
+rgb = zeros((s.numLEDs, 3), uint8)
+# s.update(rgb)
+led.fill((255, 0, 0))
+print dir(led)
+# led.update()
+for i in range(100):
+    a.step()
+# a.run()
+


### PR DESCRIPTION
The biblio_test.py runs up until "led.update()" then hangs, then exits with this error message:

` File "biblio_test.py", line 17, in <module>
    led.update()
  File "/usr/local/lib/python2.7/dist-packages/BiblioPixel-2.1.2-py2.7.egg/bibliopixel/led.py", line 201, in update
    self.driver[i]._update(data[i])
  File "/usr/local/lib/python2.7/dist-packages/BiblioPixel-2.1.2-py2.7.egg/bibliopixel/drivers/driver_base.py", line 54, in _update
    self.update(data)
  File "/usr/local/lib/python2.7/dist-packages/BiblioPixel-2.1.2-py2.7.egg/bibliopixel/drivers/serial_driver.py", line 330, in update
    DriverSerial._printError(ord(resp))
  File "/usr/local/lib/python2.7/dist-packages/BiblioPixel-2.1.2-py2.7.egg/bibliopixel/drivers/serial_driver.py", line 160, in _printError
    raise BiblioSerialError(msg)
bibliopixel.drivers.serial_driver.BiblioSerialError: Data packet size incorrect.
`
 